### PR TITLE
Moving from mysql to mysql2!

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
+/* jshint strict: true */
+
 'use strict';
 
 var Promise = require('bluebird'),
-	mysql = require('mysql'),
+	mysql = require('mysql2'),
 	instances = {};
 
 function DB() {
@@ -35,6 +37,38 @@ DB.prototype.query = function (query, params) {
 		}
 
 		con.query(query, params, function (err) {
+			if (err) {
+				if (con) {
+					con.release();
+				}
+				return defer.reject(err);
+			}
+			defer.resolve([].splice.call(arguments, 1));
+			con.release();
+		});
+	});
+	return defer.promise;
+};
+
+/**
+ * Run DB execute
+ * @param  {String} query
+ * @param  {Object} [params]
+ * @return {Promise}
+ */
+DB.prototype.execute = function (query, params) {
+	var defer = Promise.defer();
+	params = params || {};
+
+	this.pool.getConnection(function (err, con) {
+		if (err) {
+			if (con) {
+				con.release();
+			}
+			return defer.reject(err);
+		}
+
+		con.execute(query, params, function (err) {
 			if (err) {
 				if (con) {
 					con.release();

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "bluebird": "^2.1.3",
-    "mysql": "^2.3.2"
+    "mysql2": "^0.15.5"
   },
   "devDependencies": {
     "jshint": "~2.1.10",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,7 +7,11 @@ describe('mysql-promise', function () {
 		var defaultDb = db();
 		var namedDb = db('foo');
 		namedDb.should.equal(db('foo'));
+    namedDb.should.have.property('query').which.is.a.Function;
+    namedDb.should.have.property('execute').which.is.a.Function;
 		defaultDb.should.equal(db());
 		defaultDb.should.not.equal(namedDb);
+    defaultDb.should.have.property('query').which.is.a.Function;
+    defaultDb.should.have.property('execute').which.is.a.Function;
 	});
 });


### PR DESCRIPTION
Use [`mysql2`](https://github.com/sidorares/node-mysql2) lib  instead of `mysql`

There are many advantages using `mysql2` [check them ](https://github.com/sidorares/node-mysql2#features).

I added `execute` function which is simmilar to `query` but it use [prepared-statements](https://github.com/sidorares/node-mysql2#prepared-statements).