### PR TITLE
Add end() method to close all pool connections

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,23 @@ DB.prototype.query = function (query, params) {
 	return defer.promise;
 };
 
+/**
+ * End DB pool connections
+ * @return {Promise}
+ */
+DB.prototype.end = function () {
+    var defer = Promise.defer();
+
+    this.pool.end(function (err) {
+	if (err) {
+	    return defer.reject(err);
+	}
+
+	defer.resolve();
+    });
+    return defer.promise;
+};
+
 module.exports = function (name) {
 	name = name || '_default_';
 	if (!instances[name]) {

--- a/index.js
+++ b/index.js
@@ -53,16 +53,16 @@ DB.prototype.query = function (query, params) {
  * @return {Promise}
  */
 DB.prototype.end = function () {
-    var defer = Promise.defer();
+	var defer = Promise.defer();
 
-    this.pool.end(function (err) {
-	if (err) {
-	    return defer.reject(err);
-	}
+	this.pool.end(function (err) {
+		if (err) {
+			return defer.reject(err);
+		}
 
-	defer.resolve();
-    });
-    return defer.promise;
+		defer.resolve();
+	});
+	return defer.promise;
 };
 
 module.exports = function (name) {


### PR DESCRIPTION
This is useful for eg. command-line applications. If the
connections are not closed, command-line applications will hang
and never return to the prompt by themselves.